### PR TITLE
SagePay REGISTERED response should be handled as authentication.

### DIFF
--- a/merchants/sagepay.php
+++ b/merchants/sagepay.php
@@ -721,7 +721,7 @@ function sagepay_process_gateway_info() {
 			}
             break;
         case 'REGISTERED': // Only returned if TxType is AUTHENTICATE
-            $success = 'Failed';
+            $success = 'Authenticated';
             break;
         case 'OK':
             $success = 'Completed';


### PR DESCRIPTION
PR for issue #10
